### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/fucking_favicons.gemspec
+++ b/fucking_favicons.gemspec
@@ -38,7 +38,6 @@ Gem::Specification::new do |spec|
 
   spec.extensions.push(*[])
 
-  spec.rubyforge_project = "codeforpeople"
   spec.author = "Ara T. Howard"
   spec.email = "ara.t.howard@gmail.com"
   spec.homepage = "https://github.com/ahoward/fucking_favicons"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.